### PR TITLE
Bug - Enums incorrectly considered ambiguous

### DIFF
--- a/src/ExpressiveAnnotations.Tests/ParserTest.cs
+++ b/src/ExpressiveAnnotations.Tests/ParserTest.cs
@@ -521,7 +521,7 @@ namespace ExpressiveAnnotations.Tests
         {
             var parser = new Parser();
 
-            // Ensure that this doesn't consider Dog and HotDog types to be ambiguous
+            // Ensure that this doesn't consider Dog and HotDog enums to be ambiguous
             Assert.IsTrue(parser.Parse<object>("Dog.Collie == 0").Invoke(null));
 
             try

--- a/src/ExpressiveAnnotations.Tests/ParserTest.cs
+++ b/src/ExpressiveAnnotations.Tests/ParserTest.cs
@@ -26,6 +26,20 @@ namespace ExpressiveAnnotations.Tests
         Unknown
     }
 
+    public enum Dog
+    {
+        Collie,
+        Spaniel,
+        Terrier
+    }
+
+    public enum HotDog
+    {
+        Beef,
+        Pork,
+        Other
+    }
+
     public enum SbyteEnum : sbyte
     {
         First = 1,
@@ -506,6 +520,9 @@ namespace ExpressiveAnnotations.Tests
         public void verify_enumeration_ambiguity()
         {
             var parser = new Parser();
+
+            // Ensure that this doesn't consider Dog and HotDog types to be ambiguous
+            Assert.IsTrue(parser.Parse<object>("Dog.Collie == 0").Invoke(null));
 
             try
             {

--- a/src/ExpressiveAnnotations/Analysis/Parser.cs
+++ b/src/ExpressiveAnnotations/Analysis/Parser.cs
@@ -657,7 +657,7 @@ namespace ExpressiveAnnotations.Analysis
                 var enumTypeName = string.Join(".", parts.Take(parts.Count() - 1).ToList());
                 var enumTypes = AppDomain.CurrentDomain.GetAssemblies()
                     .SelectMany(a => a.GetLoadableTypes())
-                    .Where(t => t.IsEnum && t.FullName.Replace("+", ".").EndsWith(enumTypeName))
+                    .Where(t => t.IsEnum && string.Concat(".", t.FullName.Replace("+", ".")).EndsWith(string.Concat(".", enumTypeName)))
                     .ToList();
 
                 if (enumTypes.Count() > 1)


### PR DESCRIPTION
In order to detect ambiguous enum references, the existing logic compared the given enum name with the end of the fully qualified enum names in the system.  This worked for detecting ambiguous enums with the same name that were in different namespaces.  Unfortunately it also caught unambiguous enums where the given name just happened to match the end of an existing name.

The example I provided in the unit test is Dog vs HotDog.  These are unique names but the existing logic considered them ambiguous because HotDog ends with Dog.

I changed this logic to simply add a "." to the front of both the fully qualified name and the given name and then check to see if the full name ends with the given name.  So it will compare ".Something.HotDog" with ".Dog" and will not consider them to be the same, but ".Something.Dog" will still match ".Dog".

This should preserve the ambiguity check without leading to false ambiguity.