### PR TITLE
Overriding the default parser without the ValueParser annotation

### DIFF
--- a/src/expressive.annotations.validate.js
+++ b/src/expressive.annotations.validate.js
@@ -342,6 +342,7 @@ var
             return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value); // basic check
         },
         tryParse: function(value, type, name, parser) {
+            parser = parser || type;
             if (parser !== null && parser !== undefined) {
                 var parsedValue = typeHelper.tryCustomParse(value, name, parser);
                 if (!parsedValue.error) {


### PR DESCRIPTION
I've just noticed that I cant override the default validator parser when I dont provide an ValueParser annotation in my view model.

In that way I was unable to replace globally the default behavior.

In this PR I am providing a solution where when the annotation is not provided I try to fallback to the view model property type. So when I have a datetime without the annotation, I try to find a custom parser that matches the "datetime"  name.